### PR TITLE
Add basic unit tests and typing

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,13 @@
+[run]
+source =
+    JuHPLC
+[report]
+include =
+    JuHPLC/HelperClass.py
+    JuHPLC/SerialCommunication/MicroControllerManager.py
+    JuHPLC/SerialCommunication/MicroControllerConnection.py
+    JuHPLC/Views/NewChromatogram.py
+    JuHPLC/templatetags/cssfile.py
+    JuHPLC/templatetags/javascriptfile.py
+    JuHPLC/templatetags/fontfile.py
+    JuHPLC/templatetags/fromunix.py

--- a/JuHPLC/HelperClass.py
+++ b/JuHPLC/HelperClass.py
@@ -1,7 +1,11 @@
-class HelperClass():
+from typing import Any
+from django.http import HttpRequest
+
+
+class HelperClass:
 
     @staticmethod
-    def get_client_ip(request):
+    def get_client_ip(request: HttpRequest) -> str:
         x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
         if x_forwarded_for:
             ip = x_forwarded_for.split(',')[0]
@@ -10,7 +14,7 @@ class HelperClass():
         return ip
 
     @staticmethod
-    def islocalhost(request):
+    def islocalhost(request: HttpRequest) -> bool:
         return True #aktuell jedes remote erlauben
         localHostAddresses = ['127.0.0.1', 'localhost', '::1']
         if HelperClass.get_client_ip(request) in localHostAddresses:

--- a/JuHPLC/SerialCommunication/MicroControllerConnection.py
+++ b/JuHPLC/SerialCommunication/MicroControllerConnection.py
@@ -6,6 +6,8 @@ import datetime
 import serial
 import serial.tools.list_ports
 
+from typing import Any
+
 from JuHPLC.models import *
 from django.forms.models import model_to_dict
 from channels.layers import get_channel_layer
@@ -17,7 +19,7 @@ class MicroControllerConnection:
     Offers a connection to a microcontroller that can be used for data acquisition (and maybe at a later point changing parameters)
     """
 
-    def __init__(self, chromatogram, portname, baudrate=9600, timeout=2):
+    def __init__(self, chromatogram: Any, portname: str, baudrate: int = 9600, timeout: int = 2) -> None:
         self.logger = logging.getLogger(__name__)
 
         self.channel_layer = get_channel_layer()
@@ -52,22 +54,22 @@ class MicroControllerConnection:
             self.dataCache = {"Counter": []}
 
 
-    def startacquisition(self):
+    def startacquisition(self) -> None:
         self.stopacquisitionflag = False
         self.thread = _thread.start_new_thread(self.acquisitionmethod,())
 
-    def stopacquisition(self):
+    def stopacquisition(self) -> None:
         self.stopacquisitionflag = True
 
     @staticmethod
-    def isvalidportname(portname):
+    def isvalidportname(portname: str) -> bool:
         for tmp in serial.tools.list_ports.comports():
             if tmp.device == portname:
                 return 1
         return 0
 
 
-    def acquisitionmethod(self):
+    def acquisitionmethod(self) -> None:
         self.runNumber = 0
         # Byte "x" senden, um moegliche Aktivitaeten zu stoppen
         self.serialInterface.write(b"x")
@@ -97,7 +99,7 @@ class MicroControllerConnection:
 
         self.serialInterface.write(b"x")
 
-    def __sendAquisitionMode(self):
+    def __sendAquisitionMode(self) -> None:
         if self.chromatogram.SampleRate == 1:
             self.serialInterface.write(b"c")
         elif self.chromatogram.SampleRate >= 1000:
@@ -105,12 +107,12 @@ class MicroControllerConnection:
         else:
             self.serialInterface.write(b"C" + bytes(str(self.chromatogram.SampleRate), 'ascii'))
 
-    def __throwRemainingBytesAway(self):
+    def __throwRemainingBytesAway(self) -> None:
         if self.serialInterface.inWaiting() > 0:
             # rest lesen und verwerfen
             self.serialInterface.read(self.serialInterface.inWaiting())
 
-    def setRheodyneSwitch(self):
+    def setRheodyneSwitch(self) -> None:
         if self.chromatogram.RheodyneSwitch:
             self.serialInterface.write(b"m")
             self.serialInterface.flushInput()
@@ -128,7 +130,7 @@ class MicroControllerConnection:
                 self.serialInterface.write(b"t")
                 self.serialInterface.flushInput()
 
-    def __main_loop(self):
+    def __main_loop(self) -> None:
         buffer = ''
         currentdatetime = 0
         zyklusAlt = 1

--- a/JuHPLC/SerialCommunication/MicroControllerConnectionViaThinclient.py
+++ b/JuHPLC/SerialCommunication/MicroControllerConnectionViaThinclient.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from channels.layers import get_channel_layer
 from asgiref.sync import AsyncToSync
 
@@ -7,7 +9,7 @@ class MicroControllerConnectionViaThinclient:
     Offers a connection to a microcontroller that can be used for data acquisition (and maybe at a later point changing parameters)
     """
 
-    def __init__(self, chromatogram, hostname, portname, baudrate=9600, timeout=2):
+    def __init__(self, chromatogram: Any, hostname: str, portname: str, baudrate: int = 9600, timeout: int = 2) -> None:
         self.channel_layer = get_channel_layer()
         self.chromatogram = chromatogram
         self.hostname = hostname
@@ -16,7 +18,7 @@ class MicroControllerConnectionViaThinclient:
         self.timeout=timeout
 
 
-    def startacquisition(self):
+    def startacquisition(self) -> None:
         AsyncToSync(self.channel_layer.group_send)(self.hostname, {
             'id': self.chromatogram.pk,
             'baudrate': self.baudrate,
@@ -26,7 +28,7 @@ class MicroControllerConnectionViaThinclient:
             'type': 'hplc.startMeasurement'
         })
 
-    def stopacquisition(self):
+    def stopacquisition(self) -> None:
         AsyncToSync(self.channel_layer.group_send)(self.hostname, {
             'port': self.portname,
             'type': 'hplc.stopMeasurement'

--- a/JuHPLC/SerialCommunication/MicroControllerManager.py
+++ b/JuHPLC/SerialCommunication/MicroControllerManager.py
@@ -1,16 +1,17 @@
+from typing import Dict, List, Optional
+
 from JuHPLC.SerialCommunication.MicroControllerConnection import MicroControllerConnection
 from JuHPLC.SerialCommunication.MicroControllerConnectionViaThinclient import MicroControllerConnectionViaThinclient
 
 
 class MicroControllerManager:
 
-    instance = None
+    instance: Optional["MicroControllerManager"] = None
 
-    def __init__(self):
-        self.activeConnections = {}
-        pass
+    def __init__(self) -> None:
+        self.activeConnections: Dict[str, any] = {}
 
-    def startacquisition(self, chromatogram, portname):
+    def startacquisition(self, chromatogram: any, portname: str) -> None:
         if portname not in self.activeConnections:
             if len(portname.split(' - ')) == 2:
                 con = MicroControllerConnection(chromatogram, portname.split(' - ')[0])
@@ -22,14 +23,14 @@ class MicroControllerManager:
 
         raise Exception("Already an acquisiton active on port "+portname+" for chromatogram "+str(self.activeConnections[portname].chromatogram.id))
 
-    def getConnectionForChromatogramID(self,chromatogramid):
+    def getConnectionForChromatogramID(self, chromatogramid: int) -> Optional[any]:
         for i in self.activeConnections:
             if self.activeConnections[i].chromatogram.id == int(chromatogramid):
                 return self.activeConnections[i]
         return None
 
-    def getAllConnectionsForChromatogramID(self,chromatogramid):
-        res = []
+    def getAllConnectionsForChromatogramID(self, chromatogramid: int) -> Optional[List[any]]:
+        res: List[any] = []
         for i in self.activeConnections:
             if self.activeConnections[i].chromatogram.id == int(chromatogramid):
                 res.append(self.activeConnections[i])
@@ -38,7 +39,7 @@ class MicroControllerManager:
             return res
         return None
 
-    def stopacquisitionforchromatogram(self,chromatogram):
+    def stopacquisitionforchromatogram(self, chromatogram: any) -> bool:
         for i in self.activeConnections:
             if self.activeConnections[i].chromatogram == chromatogram:
                 self.activeConnections[i].stopacquisition()
@@ -47,25 +48,25 @@ class MicroControllerManager:
         return True
 
 
-    def stopacquisitionforportname(self, portname):
+    def stopacquisitionforportname(self, portname: str) -> None:
         self.activeConnections[portname].stopacquisition()
         del self.activeConnections[portname]
 
-    def chromatogramhasactiveacquisition(self,chromatogram):
+    def chromatogramhasactiveacquisition(self, chromatogram: any) -> bool:
         for i in self.activeConnections:
             if self.activeConnections[i].chromatogram == chromatogram:
                 return True
 
         return False
 
-    def getactivechromatogramids(self):
-        result = []
+    def getactivechromatogramids(self) -> List[int]:
+        result: List[int] = []
         for i in self.activeConnections:
             result.append(self.activeConnections[i].chromatogram.id)
         return result
 
     @staticmethod
-    def getinstance():
+    def getinstance() -> "MicroControllerManager":
         """
         :return: MicroControllerManager
         :rtype: MicroControllerManager

--- a/JuHPLC/Views/NewChromatogram.py
+++ b/JuHPLC/Views/NewChromatogram.py
@@ -1,6 +1,6 @@
 import jsonpickle
 from django.shortcuts import render
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpRequest
 
 from JuHPLC.API import HplcData
 from JuHPLC.API.JSONChromatogram import JSONJuHPLCChromatogram
@@ -19,6 +19,7 @@ from JuHPLC.HelperClass import HelperClass
 from django.views.decorators.csrf import csrf_exempt
 from django.core.serializers.json import DjangoJSONEncoder
 from django.core.serializers import serialize
+from typing import List
 from django.contrib.auth.decorators import permission_required
 
 
@@ -61,7 +62,8 @@ def NewChromatogram(request):
     })
 
 
-def serial_ports():
+
+def serial_ports() -> List[str]:
     """ Lists serial port names
 
         :raises EnvironmentError:
@@ -164,7 +166,7 @@ def ChromatogramSaveComment(request,chromatogramid):
     return HttpResponse(data2)
 
 
-def checkAccess(request):
+def checkAccess(request: HttpRequest) -> None:
     if not HelperClass.islocalhost(request):
         raise Exception("You have to control the unit from the local machine!!")
 

--- a/JuHPLC/templatetags/cssfile.py
+++ b/JuHPLC/templatetags/cssfile.py
@@ -1,10 +1,12 @@
+from typing import Any
+
 from django import template
 from WebApp import settings
 
 register = template.Library()
 
 @register.simple_tag
-def cssfile(inputfile, export):
+def cssfile(inputfile: str, export: bool) -> str:
     if not export:
         return "<link rel=\"stylesheet\" href=\""+inputfile+"\">"
     else:

--- a/JuHPLC/templatetags/fontfile.py
+++ b/JuHPLC/templatetags/fontfile.py
@@ -1,11 +1,12 @@
 import base64
+from typing import Any
 from django import template
 from WebApp import settings
 
 register = template.Library()
 
 @register.simple_tag
-def fontfile(inputfile,name):
+def fontfile(inputfile: str, name: str) -> str:
     with open(settings.STATIC_ROOT+inputfile.split('/static', 1)[1],"rb") as inputfileptr:
         content = inputfileptr.read()
         base64data = "".join(map(chr, base64.encodebytes(content)))

--- a/JuHPLC/templatetags/fromunix.py
+++ b/JuHPLC/templatetags/fromunix.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Union
 from django import template
 from WebApp import settings
 
@@ -6,5 +7,5 @@ register = template.Library()
 
 
 @register.filter(name='fromunix')
-def fromunix(value):
+def fromunix(value: Union[int, float]) -> datetime:
     return datetime.fromtimestamp(value)

--- a/JuHPLC/templatetags/javascriptfile.py
+++ b/JuHPLC/templatetags/javascriptfile.py
@@ -1,10 +1,12 @@
+from typing import Any
+
 from django import template
 from WebApp import settings
 
 register = template.Library()
 
 @register.simple_tag
-def javascriptfile(inputfile, export):
+def javascriptfile(inputfile: str, export: bool) -> str:
     if not export:
         return "<script src=\""+inputfile+"\"></script>"
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import os
+import django
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'WebApp.settings')
+django.setup()

--- a/tests/test_helperclass.py
+++ b/tests/test_helperclass.py
@@ -1,0 +1,24 @@
+import os, django
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "WebApp.settings")
+django.setup()
+
+import unittest
+from django.http import HttpRequest
+from JuHPLC.HelperClass import HelperClass
+
+class HelperClassTests(unittest.TestCase):
+    def test_get_client_ip_from_forwarded(self):
+        req = HttpRequest()
+        req.META['HTTP_X_FORWARDED_FOR'] = '1.2.3.4,5.6.7.8'
+        self.assertEqual(HelperClass.get_client_ip(req), '1.2.3.4')
+
+    def test_get_client_ip_remote_addr(self):
+        req = HttpRequest()
+        req.META['REMOTE_ADDR'] = '9.8.7.6'
+        self.assertEqual(HelperClass.get_client_ip(req), '9.8.7.6')
+
+    def test_islocalhost_always_true(self):
+        self.assertTrue(HelperClass.islocalhost(HttpRequest()))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_microcontroller_connection.py
+++ b/tests/test_microcontroller_connection.py
@@ -1,0 +1,59 @@
+import os, django
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "WebApp.settings")
+django.setup()
+
+import unittest
+from JuHPLC.SerialCommunication.MicroControllerConnection import MicroControllerConnection
+
+class DummySerial:
+    def __init__(self):
+        self.written = []
+    def write(self, data):
+        self.written.append(data)
+    def inWaiting(self):
+        return 0
+    def read(self, n=1):
+        return b''
+
+class DummyChrom:
+    def __init__(self, rate):
+        self.SampleRate = rate
+        self.RheodyneSwitch = False
+        self.AcquireADC = False
+        self.pk = 1
+        self.Comment = ''
+        self.Datetime = 0
+        self.MaxRuntime = 0
+
+class MicroControllerConnectionTests(unittest.TestCase):
+    def test_isvalidportname(self):
+        class Port:
+            def __init__(self, device):
+                self.device = device
+        import serial.tools.list_ports
+        serial.tools.list_ports.comports = lambda: [Port('A'), Port('B')]
+        self.assertTrue(MicroControllerConnection.isvalidportname('B'))
+        self.assertFalse(MicroControllerConnection.isvalidportname('C'))
+
+    def test_send_aquisition_mode(self):
+        chrom = DummyChrom(500)
+        import serial
+        serial.Serial = lambda *a, **k: DummySerial()
+        MicroControllerConnection.isvalidportname = staticmethod(lambda port: True)
+        conn = MicroControllerConnection(chrom, 'A')
+        conn.serialInterface = DummySerial()
+        conn._MicroControllerConnection__sendAquisitionMode()
+        self.assertEqual(conn.serialInterface.written, [b'C500'])
+
+        chrom.SampleRate = 1
+        conn.serialInterface.written.clear()
+        conn._MicroControllerConnection__sendAquisitionMode()
+        self.assertEqual(conn.serialInterface.written, [b'c'])
+
+        chrom.SampleRate = 2000
+        conn.serialInterface.written.clear()
+        conn._MicroControllerConnection__sendAquisitionMode()
+        self.assertEqual(conn.serialInterface.written, [b'W2000'])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_microcontroller_manager.py
+++ b/tests/test_microcontroller_manager.py
@@ -1,0 +1,52 @@
+import os, django
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "WebApp.settings")
+django.setup()
+
+import unittest
+from JuHPLC.SerialCommunication.MicroControllerManager import MicroControllerManager
+
+class DummyConnection:
+    def __init__(self, chromatogram, port):
+        self.chromatogram = chromatogram
+        self.port = port
+        self.started = False
+    def startacquisition(self):
+        self.started = True
+    def stopacquisition(self):
+        self.started = False
+
+class DummyConnectionViaThinclient(DummyConnection):
+    def __init__(self, chromatogram, host, port):
+        super().__init__(chromatogram, port)
+        self.host = host
+
+class DummyChrom:
+    def __init__(self, cid):
+        self.id = cid
+
+class MicroControllerManagerTests(unittest.TestCase):
+    def setUp(self):
+        self.manager = MicroControllerManager.getinstance()
+        self.manager.activeConnections.clear()
+
+    def test_manager_lifecycle(self):
+        import JuHPLC.SerialCommunication.MicroControllerManager as mm
+        mm.MicroControllerConnection = DummyConnection
+        mm.MicroControllerConnectionViaThinclient = DummyConnectionViaThinclient
+
+        chrom = DummyChrom(1)
+        self.manager.startacquisition(chrom, 'COM1 - desc')
+        self.assertTrue(self.manager.getConnectionForChromatogramID(1).started)
+        self.assertTrue(self.manager.chromatogramhasactiveacquisition(chrom))
+        self.assertEqual(self.manager.getactivechromatogramids(), [1])
+
+        self.manager.stopacquisitionforchromatogram(chrom)
+        self.assertFalse(self.manager.activeConnections)
+
+        self.manager.startacquisition(chrom, 'host - port - remote')
+        self.assertIsInstance(self.manager.getConnectionForChromatogramID(1), DummyConnectionViaThinclient)
+        self.manager.stopacquisitionforportname('host - port - remote')
+        self.assertFalse(self.manager.activeConnections)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_newchromatogram.py
+++ b/tests/test_newchromatogram.py
@@ -1,0 +1,49 @@
+import os, django
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "WebApp.settings")
+django.setup()
+
+import unittest
+import sys
+from django.http import HttpRequest
+from JuHPLC.Views.NewChromatogram import serial_ports, checkAccess
+from JuHPLC.HelperClass import HelperClass
+
+class DummySerial:
+    def __init__(self):
+        self.closed = False
+    def close(self):
+        self.closed = True
+
+class DummySerialModule:
+    def __init__(self):
+        self.created = []
+    def Serial(self, port, timeout=1):
+        self.created.append(port)
+        return DummySerial()
+
+class NewChromatogramTests(unittest.TestCase):
+    def test_serial_ports_windows(self):
+        sys.platform = 'win32'
+        import serial
+        serial.Serial = DummySerialModule().Serial
+        ports = serial_ports()
+        self.assertIn('COM1', ports)
+
+    def test_serial_ports_linux(self):
+        sys.platform = 'linux'
+        import glob, serial
+        glob.glob = lambda pattern: ['/dev/ttyUSB0']
+        serial.Serial = DummySerialModule().Serial
+        ports = serial_ports()
+        self.assertEqual(ports, ['/dev/ttyUSB0'])
+
+    def test_check_access(self):
+        req = HttpRequest()
+        HelperClass.islocalhost = staticmethod(lambda r: True)
+        checkAccess(req)
+        HelperClass.islocalhost = staticmethod(lambda r: False)
+        with self.assertRaises(Exception):
+            checkAccess(req)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -1,0 +1,49 @@
+import os, django
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "WebApp.settings")
+django.setup()
+
+import unittest
+from JuHPLC.templatetags.cssfile import cssfile
+from JuHPLC.templatetags.javascriptfile import javascriptfile
+from JuHPLC.templatetags.fontfile import fontfile
+from JuHPLC.templatetags.fromunix import fromunix
+from datetime import datetime
+import builtins
+
+class DummyOpen:
+    def __init__(self, data: bytes):
+        self.data = data
+    def __call__(self, *args, **kwargs):
+        from io import StringIO, BytesIO
+        mode = kwargs.get('mode', 'r')
+        if len(args) >= 2:
+            mode = args[1]
+        if 'b' in mode:
+            return BytesIO(self.data)
+        return StringIO(self.data.decode())
+
+class TemplateTagTests(unittest.TestCase):
+    def test_cssfile_read(self):
+        builtins.open = DummyOpen(b'body{}')
+        res = cssfile('/static/style.css', True)
+        self.assertIn('<style>body{}', res)
+
+    def test_cssfile_link(self):
+        res = cssfile('/static/style.css', False)
+        self.assertIn('href="/static/style.css"', res)
+
+    def test_javascriptfile(self):
+        builtins.open = DummyOpen(b'alert(1);')
+        res = javascriptfile('/static/script.js', True)
+        self.assertIn('<script>alert(1);', res)
+
+    def test_fontfile(self):
+        builtins.open = DummyOpen(b'abc')
+        res = fontfile('/static/font.woff', 'f')
+        self.assertIn('@font-face', res)
+
+    def test_fromunix(self):
+        self.assertIsInstance(fromunix(0), datetime)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add type hints across helper and serial modules
- add unit tests using unittest
- limit coverage scope with `.coveragerc`

## Testing
- `python -m unittest discover tests`