### PR TITLE
Enhance test coverage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,11 @@
 import os
+import sys
 import django
+
+# Ensure that the project root is part of the import path so that the
+# WebApp Django settings module can be imported when tests are executed
+# from within the ``tests`` directory.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'WebApp.settings')
 django.setup()

--- a/tests/test_microcontroller_manager.py
+++ b/tests/test_microcontroller_manager.py
@@ -48,5 +48,27 @@ class MicroControllerManagerTests(unittest.TestCase):
         self.manager.stopacquisitionforportname('host - port - remote')
         self.assertFalse(self.manager.activeConnections)
 
+    def test_get_all_connections_and_duplicate_start(self):
+        import JuHPLC.SerialCommunication.MicroControllerManager as mm
+        mm.MicroControllerConnection = DummyConnection
+        mm.MicroControllerConnectionViaThinclient = DummyConnectionViaThinclient
+
+        chrom = DummyChrom(2)
+
+        # starting two different ports for the same chromatogram
+        self.manager.startacquisition(chrom, 'COM1 - desc')
+        self.manager.startacquisition(chrom, 'COM2 - desc')
+
+        conns = self.manager.getAllConnectionsForChromatogramID(2)
+        self.assertEqual(len(conns), 2)
+
+        # starting again on an already used port should raise
+        with self.assertRaises(Exception):
+            self.manager.startacquisition(chrom, 'COM1 - desc')
+
+        # cleanup
+        self.manager.stopacquisitionforportname('COM1 - desc')
+        self.manager.stopacquisitionforportname('COM2 - desc')
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_newchromatogram.py
+++ b/tests/test_newchromatogram.py
@@ -37,6 +37,11 @@ class NewChromatogramTests(unittest.TestCase):
         ports = serial_ports()
         self.assertEqual(ports, ['/dev/ttyUSB0'])
 
+    def test_serial_ports_unsupported(self):
+        sys.platform = 'unknown'
+        with self.assertRaises(EnvironmentError):
+            serial_ports()
+
     def test_check_access(self):
         req = HttpRequest()
         HelperClass.islocalhost = staticmethod(lambda r: True)


### PR DESCRIPTION
## Summary
- ensure tests run from any working dir
- cover additional functionality in `MicroControllerManager`
- add unsupported platform case for `serial_ports`

## Testing
- `pytest -q`