### PR TITLE
Improve MicroController thinclient connection testability

### DIFF
--- a/JuHPLC/SerialCommunication/MicroControllerConnectionViaThinclient.py
+++ b/JuHPLC/SerialCommunication/MicroControllerConnectionViaThinclient.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Dict, Optional
 
 from channels.layers import get_channel_layer
 from asgiref.sync import AsyncToSync
@@ -9,27 +9,33 @@ class MicroControllerConnectionViaThinclient:
     Offers a connection to a microcontroller that can be used for data acquisition (and maybe at a later point changing parameters)
     """
 
-    def __init__(self, chromatogram: Any, hostname: str, portname: str, baudrate: int = 9600, timeout: int = 2) -> None:
-        self.channel_layer = get_channel_layer()
+    def __init__(self, chromatogram: Any, hostname: str, portname: str, baudrate: int = 9600, timeout: int = 2,
+                 channel_layer: Optional[Any] = None) -> None:
+        self.channel_layer = channel_layer or get_channel_layer()
         self.chromatogram = chromatogram
         self.hostname = hostname
         self.portname=portname
         self.baudrate=baudrate
         self.timeout=timeout
 
-
-    def startacquisition(self) -> None:
-        AsyncToSync(self.channel_layer.group_send)(self.hostname, {
+    def _build_start_message(self) -> Dict[str, Any]:
+        return {
             'id': self.chromatogram.pk,
             'baudrate': self.baudrate,
             'port': self.portname,
             'samplerate': self.chromatogram.SampleRate,
-            'rheodyneswitch':self.chromatogram.RheodyneSwitch,
+            'rheodyneswitch': self.chromatogram.RheodyneSwitch,
             'type': 'hplc.startMeasurement'
-        })
+        }
 
-    def stopacquisition(self) -> None:
-        AsyncToSync(self.channel_layer.group_send)(self.hostname, {
+    def _build_stop_message(self) -> Dict[str, Any]:
+        return {
             'port': self.portname,
             'type': 'hplc.stopMeasurement'
-        })
+        }
+
+    def startacquisition(self) -> None:
+        AsyncToSync(self.channel_layer.group_send)(self.hostname, self._build_start_message())
+
+    def stopacquisition(self) -> None:
+        AsyncToSync(self.channel_layer.group_send)(self.hostname, self._build_stop_message())

--- a/tests/test_microcontroller_connection_via_thinclient.py
+++ b/tests/test_microcontroller_connection_via_thinclient.py
@@ -1,0 +1,42 @@
+import os, django
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'WebApp.settings')
+django.setup()
+
+import unittest
+from JuHPLC.SerialCommunication.MicroControllerConnectionViaThinclient import MicroControllerConnectionViaThinclient
+
+class DummyChannelLayer:
+    def __init__(self):
+        self.sent = []
+    async def group_send(self, name, message):
+        self.sent.append((name, message))
+
+class DummyChrom:
+    def __init__(self):
+        self.pk = 1
+        self.SampleRate = 5
+        self.RheodyneSwitch = True
+
+class MicroControllerConnectionViaThinclientTests(unittest.TestCase):
+    def setUp(self):
+        self.channel = DummyChannelLayer()
+        self.chrom = DummyChrom()
+        self.conn = MicroControllerConnectionViaThinclient(self.chrom, 'host', 'port', channel_layer=self.channel)
+
+    def test_build_messages(self):
+        start_msg = self.conn._build_start_message()
+        stop_msg = self.conn._build_stop_message()
+        self.assertEqual(start_msg['id'], 1)
+        self.assertEqual(start_msg['samplerate'], 5)
+        self.assertTrue(start_msg['rheodyneswitch'])
+        self.assertEqual(stop_msg, {'port': 'port', 'type': 'hplc.stopMeasurement'})
+
+    def test_start_and_stop_acquisition_send_messages(self):
+        self.conn.startacquisition()
+        self.conn.stopacquisition()
+        self.assertEqual(self.channel.sent[0][0], 'host')
+        self.assertEqual(self.channel.sent[0][1]['type'], 'hplc.startMeasurement')
+        self.assertEqual(self.channel.sent[1][1]['type'], 'hplc.stopMeasurement')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- refactor thinclient connection to inject channel_layer and build messages separately
- add unit tests for thinclient connection

## Testing
- `pytest -q`