### PR TITLE
Fix thinclient exception handling

### DIFF
--- a/tests/test_thinclient_exception.py
+++ b/tests/test_thinclient_exception.py
@@ -1,0 +1,26 @@
+import runpy
+import sys
+import types
+import unittest
+from unittest import mock
+
+class DummyWSApp:
+    def __init__(self, *args, **kwargs):
+        pass
+    def run_forever(self):
+        raise RuntimeError('boom')
+
+dummy_websocket = types.SimpleNamespace(WebSocketApp=DummyWSApp,
+                                        enableTrace=lambda flag: None)
+
+class ThinClientExceptionTests(unittest.TestCase):
+    def test_main_loop_handles_exception(self):
+        with mock.patch.dict(sys.modules, {'websocket': dummy_websocket}):
+            with mock.patch('time.sleep', side_effect=[None, StopIteration()]):
+                with mock.patch('logging.exception') as log_exc:
+                    with self.assertRaises(StopIteration):
+                        runpy.run_module('thinclient', run_name='__main__')
+                    log_exc.assert_called()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/thinclient.py
+++ b/thinclient.py
@@ -264,6 +264,5 @@ if __name__ == "__main__":
                                       on_close=on_close)
             ws.on_open = on_open
             ws.run_forever()
-        except ex:
-            print("exception, restarting connection to server")
-            print(ex)
+        except Exception as ex:
+            logging.exception("exception, restarting connection to server")


### PR DESCRIPTION
## Summary
- fix bare except in thinclient and use logging for errors
- ensure thinclient ends with newline
- add regression test for main loop error handling

## Testing
- `pytest -q`