### PR TITLE
Add admin registration and documentation

### DIFF
--- a/JuHPLC/admin.py
+++ b/JuHPLC/admin.py
@@ -1,3 +1,54 @@
 from django.contrib import admin
 
-# Register your models here.
+from .models import (
+    Chromatogram,
+    Eluent,
+    Solvent,
+    HplcData,
+    Peak,
+    Baseline,
+    Calibration,
+    Marker,
+)
+
+
+class ChromatogramAdmin(admin.ModelAdmin):
+    list_display = ("id", "Sample", "Datetime", "User")
+
+
+class EluentAdmin(admin.ModelAdmin):
+    list_display = ("id", "Chromatogram")
+
+
+class SolventAdmin(admin.ModelAdmin):
+    list_display = ("Name", "Percentage", "Eluent")
+
+
+class HplcDataAdmin(admin.ModelAdmin):
+    list_display = ("id", "Chromatogram", "ChannelName", "Datetime", "Value")
+
+
+class PeakAdmin(admin.ModelAdmin):
+    list_display = ("Chromatogram", "ChannelName", "StartTime", "EndTime", "Name")
+
+
+class BaselineAdmin(admin.ModelAdmin):
+    list_display = ("Chromatogram", "ChannelName", "Type")
+
+
+class CalibrationAdmin(admin.ModelAdmin):
+    list_display = ("Name", "Slope", "YAxisIntercept", "Channel")
+
+
+class MarkerAdmin(admin.ModelAdmin):
+    list_display = ("Chromatogram", "Time", "Text")
+
+
+admin.site.register(Chromatogram, ChromatogramAdmin)
+admin.site.register(Eluent, EluentAdmin)
+admin.site.register(Solvent, SolventAdmin)
+admin.site.register(HplcData, HplcDataAdmin)
+admin.site.register(Peak, PeakAdmin)
+admin.site.register(Baseline, BaselineAdmin)
+admin.site.register(Calibration, CalibrationAdmin)
+admin.site.register(Marker, MarkerAdmin)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ python3 /home/pi/JuHPLC/manage.py createsuperuser
 ```
 and following the instructions on screen.
 
+Once your server is running you can visit ``/admin/`` on the same host and
+log in with the superuser credentials to manage chromatograms and related
+data.
+
 ## Running the tests
 
 Currently none - Todo

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -23,6 +23,12 @@ After this it is required to create a user account using:
 
 and following the instructions on screen.
 
+Admin Interface
+~~~~~~~~~~~~~~~
+Start the development server and navigate to ``/admin/`` on your device.
+Log in with the superuser account you just created to manage chromatograms
+and other data through Django's built-in interface.
+
 Usage
 ~~~~~
 Use your favourite webbrowser and connect to the IP-address / name of the raspberry with it.


### PR DESCRIPTION
## Summary
- register Chromatogram-related models in `admin.py`
- show key fields in admin list display
- document admin site access in README and getting started docs

## Testing
- `pytest -q`