### PR TITLE
Fix acquisition typo with custom exception

### DIFF
--- a/JuHPLC/SerialCommunication/MicroControllerManager.py
+++ b/JuHPLC/SerialCommunication/MicroControllerManager.py
@@ -1,7 +1,17 @@
 from typing import Dict, List, Optional
 
-from JuHPLC.SerialCommunication.MicroControllerConnection import MicroControllerConnection
-from JuHPLC.SerialCommunication.MicroControllerConnectionViaThinclient import MicroControllerConnectionViaThinclient
+from JuHPLC.SerialCommunication.MicroControllerConnection import (
+    MicroControllerConnection,
+)
+from JuHPLC.SerialCommunication.MicroControllerConnectionViaThinclient import (
+    MicroControllerConnectionViaThinclient,
+)
+
+
+class ActiveAcquisitionError(Exception):
+    """Raised when a port already has an active acquisition."""
+
+    pass
 
 
 class MicroControllerManager:
@@ -21,7 +31,12 @@ class MicroControllerManager:
             con.startacquisition()
             return
 
-        raise Exception("Already an acquisiton active on port "+portname+" for chromatogram "+str(self.activeConnections[portname].chromatogram.id))
+        raise ActiveAcquisitionError(
+            "Already an acquisition active on port "
+            + portname
+            + " for chromatogram "
+            + str(self.activeConnections[portname].chromatogram.id)
+        )
 
     def getConnectionForChromatogramID(self, chromatogramid: int) -> Optional[any]:
         for i in self.activeConnections:

--- a/tests/test_microcontroller_manager.py
+++ b/tests/test_microcontroller_manager.py
@@ -3,7 +3,10 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "WebApp.settings")
 django.setup()
 
 import unittest
-from JuHPLC.SerialCommunication.MicroControllerManager import MicroControllerManager
+from JuHPLC.SerialCommunication.MicroControllerManager import (
+    MicroControllerManager,
+    ActiveAcquisitionError,
+)
 
 class DummyConnection:
     def __init__(self, chromatogram, port):
@@ -63,7 +66,7 @@ class MicroControllerManagerTests(unittest.TestCase):
         self.assertEqual(len(conns), 2)
 
         # starting again on an already used port should raise
-        with self.assertRaises(Exception):
+        with self.assertRaises(ActiveAcquisitionError):
             self.manager.startacquisition(chrom, 'COM1 - desc')
 
         # cleanup


### PR DESCRIPTION
## Summary
- fix typo in MicroControllerManager error message
- introduce `ActiveAcquisitionError` exception
- update tests to expect the new exception

## Testing
- `pytest -q`